### PR TITLE
Fix number queries

### DIFF
--- a/lib/textquery/textquery.rb
+++ b/lib/textquery/textquery.rb
@@ -17,7 +17,7 @@ else
   RegExp::IGNORECACASE = Regexp::IGNORECASE
 end
 
-FUZZY = RegExp.new('(\d)*(~)?([^~]+)(~)?(\d)*$')
+FUZZY = RegExp.new('(?:(\d)*(~))?([^~]+)(?:(~)?(\d)*)$')
 
 class WordMatch < Treetop::Runtime::SyntaxNode
 

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -204,6 +204,11 @@ describe TextQuery do
     q.parse("~更は出~ OR ~尽く~").eval(JP).should be_true
   end
 
+  it "should work with queries starting with numbers" do
+    q = TextQuery.new('3827')
+    q.parse('abc 123 3827 9382').should be_true
+  end
+
   it "should be case insensitive" do
     TextQuery.new("a", :ignorecase => true).match?("A b cD").should be_true
     TextQuery.new("a AND CD", :ignorecase => true).match?("A b cD").should be_true


### PR DESCRIPTION
There is a bug where if a word that is searched for starts with a digit, it will be swallowed by the fuzzy query matcher when it shouldn't be.
