### PR TITLE
Ensure we do not swallow spaces inside quoted strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 pkg
+.bundle
+Gemfile.lock
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "http://rubygems.org"
 
 gemspec
+
+platform :mri_18 do
+  gem 'activesupport', '~> 2.3.5'
+  gem 'oniguruma'
+end

--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -105,7 +105,7 @@ grammar TextQueryGrammar
       end
     }
     /
-    double_quote space double_quote_words space double_quote {
+    double_quote double_quote_words double_quote {
       def eval(text, opt)
         double_quote_words.eval(text, opt)
       end
@@ -115,7 +115,7 @@ grammar TextQueryGrammar
       end
     }
     /
-    single_quote space single_quote_words space single_quote {
+    single_quote single_quote_words single_quote {
       def eval(text, opt)
         single_quote_words.eval(text, opt)
       end

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -14,7 +14,7 @@ require "textquery"
 #
 
 describe TextQuery do
-  before(:all) do
+  before(:each) do
     @parser = TextQuery.new
   end
 
@@ -134,6 +134,11 @@ describe TextQuery do
     # shakespeare got nothin' on ruby...
     parse("'to be' OR NOT 'to be'").eval("to be").should be_true
     parse('"to be" OR NOT "to be"').eval("to be").should be_true
+  end
+
+  it "should not swallow spaces inside quoted strings" do
+    parse('" some text "').eval("this is some text", :delim => '').should be_false
+    parse('" some text "').eval("this is some text that should match", :delim => '').should be_true
   end
 
   it "should accept unbalanced quotes" do
@@ -269,6 +274,11 @@ describe TextQuery do
     it 'should allow query to be traversed' do
       TextQuery.new("a b").accept { |*a| a }.should == [ :and, [ :value, 'a' ], [ :value, 'b' ] ]
       TextQuery.new("a OR b").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :value, 'b' ] ]
+    end
+
+    it 'should not swallow spaces in quoted strings when traversed' do
+      TextQuery.new('" a "').accept { |*a| a }.should == [ :value, ' a ' ]
+
     end
   end
 end


### PR DESCRIPTION
We've found cases where the spaces in " something " get swallowed but in our use case we want to know about them to be able to match against them specifically.
