### PR TITLE
Fixed problem with large FUZZY counts, use named captures

### DIFF
--- a/lib/textquery/textquery.rb
+++ b/lib/textquery/textquery.rb
@@ -33,13 +33,13 @@ class WordMatch < Treetop::Runtime::SyntaxNode
 
       q = []
       if fuzzy[:startfuzz]
-	q.push "."
-	q.push fuzzy[:startcount].empty? ? "*" : "{#{fuzzy[:startcount]}}"
+        q.push "."
+        q.push fuzzy[:startcount].empty? ? "*" : "{#{fuzzy[:startcount]}}"
       end
       q.push fuzzy[:text]
       if fuzzy[4]
-	q.push "."
-	q.push fuzzy[:endcount].empty? ? "*" : "{#{fuzzy[:endcount]}}"
+        q.push "."
+        q.push fuzzy[:endcount].empty? ? "*" : "{#{fuzzy[:endcount]}}"
       end
       q = q.join
 

--- a/lib/textquery/textquery.rb
+++ b/lib/textquery/textquery.rb
@@ -17,7 +17,7 @@ else
   RegExp::IGNORECACASE = Regexp::IGNORECASE
 end
 
-FUZZY = RegExp.new('(?:(\d)*(~))?([^~]+)(?:(~)?(\d)*)$')
+FUZZY = RegExp.new('(?:(?<startcount>\d*)(?<startfuzz>~))?(?<text>[^~]+)(?:(?<endfuzz>~)?(?<endcount>\d*))$')
 
 class WordMatch < Treetop::Runtime::SyntaxNode
 
@@ -32,11 +32,15 @@ class WordMatch < Treetop::Runtime::SyntaxNode
       fuzzy = FUZZY.match(query)
 
       q = []
-      q.push "."                                    if fuzzy[2]
-      q.push fuzzy[1].nil? ? "*" : "{#{fuzzy[1]}}"  if fuzzy[2]
-      q.push fuzzy[3]
-      q.push "."                                    if fuzzy[4]
-      q.push fuzzy[5].nil? ? "*" : "{#{fuzzy[5]}}"  if fuzzy[4]
+      if fuzzy[:startfuzz]
+	q.push "."
+	q.push fuzzy[:startcount].empty? ? "*" : "{#{fuzzy[:startcount]}}"
+      end
+      q.push fuzzy[:text]
+      if fuzzy[4]
+	q.push "."
+	q.push fuzzy[:endcount].empty? ? "*" : "{#{fuzzy[:endcount]}}"
+      end
       q = q.join
 
       regex = "(^|#{opt[:delim]})#{q}(#{opt[:delim]}|$)"

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -193,6 +193,9 @@ describe TextQuery do
     parse("2~a~1").eval("daf").should be_false
     parse("1~a~2").eval("daf").should be_false
 
+    parse("a~10").eval("a1234567890").should be_true
+    parse("10~a").eval("1234567890a").should be_true
+
     parse("~a~3").eval("daffy").should be_true
     parse("a~1").eval("adf").should be_false
 


### PR DESCRIPTION
The regular expression for fuzzy matching was incorrect, since the capture group for a single digit was inside the \* which supports multiple digits. As a result, any multi-digit fuzz count like "10~foo" failed. This change fixes that, and makes the code more readable by using named capture groups in the regular expression.
