### PR TITLE
Lexing of boolean operators failed when they were used as prefix to a wo...

### DIFF
--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -27,7 +27,7 @@ grammar TextQueryGrammar
   end
 
   rule binary
-    'AND' {
+    'AND' !alphanumeric {
       def eval(a,b)
         a && b
       end
@@ -37,7 +37,7 @@ grammar TextQueryGrammar
       end
     }
     /
-    'OR' {
+    'OR' !alphanumeric {
       def eval(a,b)
         a || b
       end
@@ -49,7 +49,7 @@ grammar TextQueryGrammar
   end
 
   rule unary
-    ('-' / 'NOT') {
+    ('-' / 'NOT' !alphanumeric) {
       def eval(a)
         not a
       end
@@ -78,6 +78,15 @@ grammar TextQueryGrammar
 
   rule double_quote
     ["]
+  end
+
+  rule alpha
+    # Any character except USASCII non-alphas. Pretty dodgey, but Treetop makes anything else rather hard
+    [^\x00-\x40\x5B-\x5E\x60\x7B-\x7F]
+  end
+
+  rule alphanumeric
+    alpha / [0-9]
   end
 
   rule double_quote_words

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -28,16 +28,16 @@ describe TextQuery do
     parse("text").eval("some textstring").should be_false
     parse("text").eval("string of texts stuff").should be_false
     parse("$^").eval("string of $^* stuff").should be_false
+    parse("NOTEWORTHY").eval("NOTEWORTHY string of EWORTHY stuff").should be_true
     parse("NOTtext").eval("string of stuff").should be_false
-    parse("NOTtext").eval("string of NOTtext stuff with text").should be_true
   end
 
   it "should accept logical AND" do
     parse("a AND b").eval("c").should be_false
     parse("a AND b").eval("a").should be_false
     parse("a AND b").eval("b").should be_false
-    parse("a ANDb").eval("a b").should be_false
-    parse("a ANDb").eval("a ANDb").should be_true
+    parse("ORVILLE ANDREWS").eval("ORVILLE DREWS").should be_false
+    parse("ORVILLE ANDREWS").eval("ANDREWS ORVILLE").should be_true
 
     parse("a AND b").eval("a b").should be_true
     parse("a AND b").eval("a c b").should be_true
@@ -45,9 +45,9 @@ describe TextQuery do
 
   it "should accept logical OR" do
     parse("a OR b").eval("c").should be_false
-    parse("a ORb").eval("b").should be_false
     parse("a OR b").eval("a").should be_true
     parse("a OR b").eval("b").should be_true
+    parse("ANDREWS ORVILLE").eval("VILLE").should be_false
 
     parse("a OR b").eval("a b").should be_true
     parse("a OR b").eval("a c b").should be_true

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -28,12 +28,16 @@ describe TextQuery do
     parse("text").eval("some textstring").should be_false
     parse("text").eval("string of texts stuff").should be_false
     parse("$^").eval("string of $^* stuff").should be_false
+    parse("NOTtext").eval("string of stuff").should be_false
+    parse("NOTtext").eval("string of NOTtext stuff with text").should be_true
   end
 
   it "should accept logical AND" do
     parse("a AND b").eval("c").should be_false
     parse("a AND b").eval("a").should be_false
     parse("a AND b").eval("b").should be_false
+    parse("a ANDb").eval("a b").should be_false
+    parse("a ANDb").eval("a ANDb").should be_true
 
     parse("a AND b").eval("a b").should be_true
     parse("a AND b").eval("a c b").should be_true
@@ -41,6 +45,7 @@ describe TextQuery do
 
   it "should accept logical OR" do
     parse("a OR b").eval("c").should be_false
+    parse("a ORb").eval("b").should be_false
     parse("a OR b").eval("a").should be_true
     parse("a OR b").eval("b").should be_true
 


### PR DESCRIPTION
When a match word began with the letters AND, OR, NOT, this was mistakenly parsed as being a boolean operator. This fixes that and tests against regression.
