### PR TITLE
Implement standard precedence for boolean operators, not just left-to-ri...

### DIFF
--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -1,49 +1,59 @@
 grammar TextQueryGrammar
 
   rule expression
-     logical / value
+     alternates / value
   end
 
-  rule logical
-    op1:value space operator:binary space op2:expression {
+  rule alternates
+    c1:conjunction space or space c2:conjunction {
       def eval(text, opt)
-        operator.eval(op1.eval(text, opt), op2.eval(text, opt))
+        c1.eval(text, opt) || c2.eval(text, opt)
       end
 
       def accept(&block)
-        operator.accept(op1.accept(&block), op2.accept(&block), &block)
+        block.call(:or, c1.accept(&block), c2.accept(&block), &block)
       end
     }
     /
-    op1:value [\s]+ op2:expression {
-        def eval(text, opt)
-          op1.eval(text, opt) && op2.eval(text, opt)
-        end
-
-        def accept(&block)
-          block.call(:and, op1.accept(&block), op2.accept(&block))
-        end
-      }
+    conjunction
   end
 
-  rule binary
-    'AND' {
-      def eval(a,b)
-        a && b
+  rule or
+    'OR' ![A-Za-z0-9]
+  end
+
+  rule and
+    'AND' ![A-Za-z0-9]
+  end
+
+  rule conjunction
+    !or op1:value space and space op2:conjunction {
+      def eval(text, opt)
+        op1.eval(text, opt) && op2.eval(text, opt)
       end
 
-      def accept(a, b, &block)
-        block.call(:and, a, b)
+      def accept(&block)
+        block.call(:and, op1.accept(&block), op2.accept(&block), &block)
       end
     }
     /
-    'OR' {
-      def eval(a,b)
-        a || b
+    !or op1:value [\s]+ op2:conjunction {
+      def eval(text, opt)
+        op1.eval(text, opt) && op2.eval(text, opt)
       end
 
-      def accept(a, b, &block)
-        block.call(:or, a, b)
+      def accept(&block)
+        block.call(:and, op1.accept(&block), op2.accept(&block))
+      end
+    }
+    /
+    !or op1:value {
+      def eval(text, opt)
+        op1.eval(text, opt)
+      end
+
+      def accept(&block)
+        op1.accept(&block)
       end
     }
   end
@@ -125,6 +135,14 @@ grammar TextQueryGrammar
       end
     }
     /
-    word
+    !(or / and) word {
+      def eval(text, opt)
+        word.eval(text, opt)
+      end
+
+      def accept(&block)
+        word.accept(&block)
+      end
+    }
   end
 end

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -49,13 +49,13 @@ describe TextQuery do
   end
 
   it "should give precedence to AND" do
-    # a AND (b OR c) == a AND b OR c
+    # (a AND b) OR c == a AND b OR c
     parse("a AND b OR c").eval("a b c").should be_true
     parse("a AND b OR c").eval("a b").should be_true
     parse("a AND b OR c").eval("a c").should be_true
 
-    parse("a AND b OR c").eval("b c").should be_false
-    parse("a AND b OR c").eval("c").should be_false
+    parse("a AND b OR c").eval("b c").should be_true
+    parse("a AND b OR c").eval("c").should be_true
     parse("a AND b OR c").eval("b").should be_false
   end
 


### PR DESCRIPTION
There were several problems here:

1) The code actually implemented simple left-to-right precedence, whether AND or OR. This PR fixes that

2) The test states "give precedence to AND", but the examples and comment actually gave higher precedence to OR

3) The standard precedence for algebraic logic is for AND to have higher precedence (gets evaluated first, like multiplication).

This PR implements the standard precedence and tests for it.
