### PR TITLE
OR may now be chained

### DIFF
--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -5,7 +5,7 @@ grammar TextQueryGrammar
   end
 
   rule alternates
-    c1:conjunction space or space c2:conjunction {
+    c1:conjunction space or space c2:alternates {
       def eval(text, opt)
         c1.eval(text, opt) || c2.eval(text, opt)
       end
@@ -16,18 +16,6 @@ grammar TextQueryGrammar
     }
     /
     conjunction
-  end
-
-  rule or
-    'OR' ![A-Za-z0-9]
-  end
-
-  rule and
-    'AND' ![A-Za-z0-9]
-  end
-
-  rule not
-    'NOT' ![A-Za-z0-9]
   end
 
   rule conjunction
@@ -72,6 +60,18 @@ grammar TextQueryGrammar
         block.call(:not, a)
       end
     }
+  end
+
+  rule or
+    'OR' ![A-Za-z0-9]
+  end
+
+  rule and
+    'AND' ![A-Za-z0-9]
+  end
+
+  rule not
+    'NOT' ![A-Za-z0-9]
   end
 
   rule space

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -36,21 +36,25 @@ describe TextQuery do
     parse("a AND b").eval("c").should be_false
     parse("a AND b").eval("a").should be_false
     parse("a AND b").eval("b").should be_false
+    parse("a AND b AND c").eval("a b").should be_false
     parse("ORVILLE ANDREWS").eval("ORVILLE DREWS").should be_false
     parse("ORVILLE ANDREWS").eval("ANDREWS ORVILLE").should be_true
 
     parse("a AND b").eval("a b").should be_true
     parse("a AND b").eval("a c b").should be_true
+    parse("a AND b AND c").eval("a c b").should be_true
   end
 
   it "should accept logical OR" do
     parse("a OR b").eval("c").should be_false
     parse("a OR b").eval("a").should be_true
     parse("a OR b").eval("b").should be_true
+    parse("a OR b OR c").eval("d").should be_false
     parse("ANDREWS ORVILLE").eval("VILLE").should be_false
 
     parse("a OR b").eval("a b").should be_true
     parse("a OR b").eval("a c b").should be_true
+    parse("a OR b OR c").eval("a c b").should be_true
   end
 
   it "should give precedence to AND" do


### PR DESCRIPTION
The AND operator allowed chaining of any number of AND expressions, but the OR operator did not. This patch fixes that, and moves minor lexical rules out of the way a little.
