### PR TITLE
Add attribute tag support, including with a custom attribute delimiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ pkg
 .bundle
 Gemfile.lock
 .DS_Store
+.*.swp
+.*.swo

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Textquery is a simple PEG grammar with support for:
 - 'quoted strings'
 - fuzzy matching
 - case (in)sensitive
-- custom delimeters
+- attribute tags (e.g. surname:Smith)
+- custom delimiters (default is whitespace for words, : for attributes)
 
 TextQuery in the wild: [PostRank](http://postrank.com/), [PaperTrail](https://papertrailapp.com/), and others!
 

--- a/lib/textquery/textquery.rb
+++ b/lib/textquery/textquery.rb
@@ -81,7 +81,7 @@ class TextQueryGrammarParser
 
   def _nt_attribute_delimiter
     attribute_delimiter = options.has_key?(:attribute_delimiter) ? options[:attribute_delimiter] : ':'
-    if attribute_delimiter && has_terminal?(attribute_delimiter, false, index)
+    if attribute_delimiter && attribute_delimiter.size > 0 && has_terminal?(attribute_delimiter, false, index)
       attribute_delimiter_size = attribute_delimiter.size
       r0 = instantiate_node(SyntaxNode,input, index...(index + attribute_delimiter_size))
       @index += attribute_delimiter_size

--- a/lib/textquery/textquery.rb
+++ b/lib/textquery/textquery.rb
@@ -66,12 +66,39 @@ Treetop.load File.dirname(__FILE__) + "/textquery_grammar"
 class TextQueryError < RuntimeError
 end
 
+class TextQueryGrammarParser
+  attr_reader :options
+
+  def initialize options = {}
+    @options = options
+    super()
+  end
+
+  def update_options(options)
+    @options = {:delim => ' '}.merge(options)
+    @options[:delim] = "(#{[@options[:delim]].flatten.map { |opt| opt.is_a?(Regexp) ? opt : RegExp.escape(opt) }.join("|")})"
+  end
+
+  def _nt_attribute_delimiter
+    attribute_delimiter = options.has_key?(:attribute_delimiter) ? options[:attribute_delimiter] : ':'
+    if attribute_delimiter && has_terminal?(attribute_delimiter, false, index)
+      attribute_delimiter_size = attribute_delimiter.size
+      r0 = instantiate_node(SyntaxNode,input, index...(index + attribute_delimiter_size))
+      @index += attribute_delimiter_size
+    else
+      terminal_parse_failure(attribute_delimiter)
+      r0 = nil
+    end
+    r0
+  end
+end
+
 class TextQuery
   def initialize(query = '', options = {})
-    @parser = TextQueryGrammarParser.new
+    @parser = TextQueryGrammarParser.new options
     @query  = nil
 
-    update_options(options)
+    @parser.update_options(options)
     parse(query) if not query.empty?
   end
 
@@ -85,10 +112,10 @@ class TextQuery
   end
 
   def eval(input, options = {})
-    update_options(options) if not options.empty?
+    @parser.update_options(options) if not options.empty?
 
     if @query
-      @query.eval(input, @options)
+      @query.eval(input, @parser.options)
     else
       raise TextQueryError, 'no query specified'
     end
@@ -96,7 +123,7 @@ class TextQuery
   alias :match? :eval
 
   def accept(options = {}, &block)
-    update_options(options) if not options.empty?
+    @parser.update_options(options) if not options.empty?
 
     if @query
       @query.accept(&block)
@@ -109,10 +136,4 @@ class TextQuery
     @parser.terminal_failures
   end
 
-  private
-
-    def update_options(options)
-      @options = {:delim => ' '}.merge(options)
-      @options[:delim] = "(#{[@options[:delim]].flatten.map { |opt| opt.is_a?(Regexp) ? opt : RegExp.escape(opt) }.join("|")})"
-    end
 end

--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -1,11 +1,11 @@
 grammar TextQueryGrammar
 
   rule expression
-     logical / value
+     logical / term
   end
 
   rule logical
-    op1:value space operator:binary space op2:expression {
+    op1:term space operator:binary space op2:expression {
       def eval(text, opt)
         operator.eval(op1.eval(text, opt), op2.eval(text, opt))
       end
@@ -15,7 +15,7 @@ grammar TextQueryGrammar
       end
     }
     /
-    op1:value [\s]+ op2:expression {
+    op1:term [\s]+ op2:expression {
         def eval(text, opt)
           op1.eval(text, opt) && op2.eval(text, opt)
         end
@@ -84,6 +84,35 @@ grammar TextQueryGrammar
     [^"]+ <WordMatch>
   end
 
+  rule alpha
+    # Any character except USASCII non-alphas. Pretty dodgey, but Treetop makes anything else rather hard
+    [^\x00-\x40\x5B-\x5E\x60\x7B-\x7F]
+  end
+
+  rule alphanumeric
+    alpha / [0-9]
+  end
+
+  rule attribute
+    alpha alphanumeric*
+  end
+
+  rule term
+    attribute ':' value
+    # If you wish to restrict the allowed attributes, add a sempred here:
+    # &{|s| is_valid_attribute(s[0].text_value) }
+    {
+      def eval(text, opt)
+	value.eval(text, opt)
+      end
+      def accept(&block)
+        block.call(:attribute, attribute.text_value, value.accept(&block))
+      end
+    }
+    /
+    value
+  end
+
   rule value
     '(' space expression space ')' {
        def eval(text, opt)
@@ -95,13 +124,13 @@ grammar TextQueryGrammar
        end
     }
     /
-    operator:unary space value {
+    operator:unary space term {
       def eval(text, opt)
-        operator.eval(value.eval(text, opt))
+        operator.eval(term.eval(text, opt))
       end
 
       def accept(&block)
-        operator.accept(value.accept(&block), &block)
+        operator.accept(term.accept(&block), &block)
       end
     }
     /

--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -101,8 +101,7 @@ grammar TextQueryGrammar
   end
 
   rule alpha
-    # Any character except USASCII non-alphas. Pretty dodgey, but Treetop makes anything else rather hard
-    [^\x00-\x40\x5B-\x5E\x60\x7B-\x7F]
+    [[:alpha:]]
   end
 
   rule alphanumeric
@@ -114,7 +113,7 @@ grammar TextQueryGrammar
   end
 
   rule term
-    attribute ':' value
+    attribute attribute_delimiter value
     # If you wish to restrict the allowed attributes, add a sempred here:
     # &{|s| is_valid_attribute(s[0].text_value) }
     {

--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -1,3 +1,5 @@
+# Encoding: UTF-8
+
 grammar TextQueryGrammar
 
   rule expression

--- a/lib/textquery/textquery_grammar.treetop
+++ b/lib/textquery/textquery_grammar.treetop
@@ -27,7 +27,7 @@ grammar TextQueryGrammar
   end
 
   rule binary
-    'AND' {
+    'AND' !alphanumeric {
       def eval(a,b)
         a && b
       end
@@ -37,7 +37,7 @@ grammar TextQueryGrammar
       end
     }
     /
-    'OR' {
+    'OR' !alphanumeric {
       def eval(a,b)
         a || b
       end
@@ -49,7 +49,7 @@ grammar TextQueryGrammar
   end
 
   rule unary
-    ('-' / 'NOT') {
+    ('-' / 'NOT' !alphanumeric) {
       def eval(a)
         not a
       end
@@ -78,6 +78,15 @@ grammar TextQueryGrammar
 
   rule double_quote
     ["]
+  end
+
+  rule alpha
+    # Any character except USASCII non-alphas. Pretty dodgey, but Treetop makes anything else rather hard
+    [^\x00-\x40\x5B-\x5E\x60\x7B-\x7F]
+  end
+
+  rule alphanumeric
+    alpha / [0-9]
   end
 
   rule double_quote_words

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -276,9 +276,21 @@ describe TextQuery do
       TextQuery.new("a OR b").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :value, 'b' ] ]
     end
 
+    it 'should allow query with attribute' do
+      pending "Adding tests before implementing code, like a good boy should" do
+	TextQuery.new("tag:b").accept { |*a| a }.should == [ :attribute, 'tag', [ :value, 'b' ] ]
+	TextQuery.new("a OR tag:b").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :attribute, 'tag', [ :value, 'b' ] ] ]
+	TextQuery.new("a OR tag:'b c'").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :attribute, 'tag', [ :value, 'b c' ] ] ]
+	TextQuery.new("a -tag:'b c'").accept { |*a| a }.should == [ :and, [ :value, 'a' ], [ :not, [ :attribute, 'tag', [ :value, 'b c' ] ] ] ]
+      end
+    end
+
+    it 'should allow query with syntax similar to attributes' do
+      TextQuery.new("notatag;b").accept { |*a| a }.should == [ :value, 'notatag;b' ]
+    end
+
     it 'should not swallow spaces in quoted strings when traversed' do
       TextQuery.new('" a "').accept { |*a| a }.should == [ :value, ' a ' ]
-
     end
   end
 end

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -28,16 +28,16 @@ describe TextQuery do
     parse("text").eval("some textstring").should be_false
     parse("text").eval("string of texts stuff").should be_false
     parse("$^").eval("string of $^* stuff").should be_false
+    parse("NOTEWORTHY").eval("NOTEWORTHY string of EWORTHY stuff").should be_true
     parse("NOTtext").eval("string of stuff").should be_false
-    parse("NOTtext").eval("string of NOTtext stuff with text").should be_true
   end
 
   it "should accept logical AND" do
     parse("a AND b").eval("c").should be_false
     parse("a AND b").eval("a").should be_false
     parse("a AND b").eval("b").should be_false
-    parse("a ANDb").eval("a b").should be_false
-    parse("a ANDb").eval("a ANDb").should be_true
+    parse("ORVILLE ANDREWS").eval("ORVILLE DREWS").should be_false
+    parse("ORVILLE ANDREWS").eval("ANDREWS ORVILLE").should be_true
 
     parse("a AND b").eval("a b").should be_true
     parse("a AND b").eval("a c b").should be_true
@@ -45,9 +45,9 @@ describe TextQuery do
 
   it "should accept logical OR" do
     parse("a OR b").eval("c").should be_false
-    parse("a ORb").eval("b").should be_false
     parse("a OR b").eval("a").should be_true
     parse("a OR b").eval("b").should be_true
+    parse("ANDREWS ORVILLE").eval("VILLE").should be_false
 
     parse("a OR b").eval("a b").should be_true
     parse("a OR b").eval("a c b").should be_true

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -277,12 +277,10 @@ describe TextQuery do
     end
 
     it 'should allow query with attribute' do
-      pending "Adding tests before implementing code, like a good boy should" do
-	TextQuery.new("tag:b").accept { |*a| a }.should == [ :attribute, 'tag', [ :value, 'b' ] ]
-	TextQuery.new("a OR tag:b").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :attribute, 'tag', [ :value, 'b' ] ] ]
-	TextQuery.new("a OR tag:'b c'").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :attribute, 'tag', [ :value, 'b c' ] ] ]
-	TextQuery.new("a -tag:'b c'").accept { |*a| a }.should == [ :and, [ :value, 'a' ], [ :not, [ :attribute, 'tag', [ :value, 'b c' ] ] ] ]
-      end
+      TextQuery.new("tag:b").accept { |*a| a }.should == [ :attribute, 'tag', [ :value, 'b' ] ]
+      TextQuery.new("a OR tag:b").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :attribute, 'tag', [ :value, 'b' ] ] ]
+      TextQuery.new("a OR tag:'b c'").accept { |*a| a }.should == [ :or, [ :value, 'a' ], [ :attribute, 'tag', [ :value, 'b c' ] ] ]
+      TextQuery.new("a -tag:'b c'").accept { |*a| a }.should == [ :and, [ :value, 'a' ], [ :not, [ :attribute, 'tag', [ :value, 'b c' ] ] ] ]
     end
 
     it 'should allow query with syntax similar to attributes' do

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -295,6 +295,14 @@ describe TextQuery do
       TextQuery.new("a -tag:'b c'").accept { |*a| a }.should == [ :and, [ :value, 'a' ], [ :not, [ :attribute, 'tag', [ :value, 'b c' ] ] ] ]
     end
 
+    it 'should allow query with attribute using custom delimiter' do
+      TextQuery.new("tag#b", :attribute_delimiter => '#').accept { |*a| a }.should == [ :attribute, 'tag', [ :value, 'b' ] ]
+    end
+
+    it 'should allow query disabling the attribute delimiter' do
+      TextQuery.new("tag:b", :attribute_delimiter => nil).accept { |*a| a }.should == [ :value, 'tag:b' ]
+    end
+
     it 'should allow query with syntax similar to attributes' do
       TextQuery.new("notatag;b").accept { |*a| a }.should == [ :value, 'notatag;b' ]
     end

--- a/spec/textquery_spec.rb
+++ b/spec/textquery_spec.rb
@@ -28,12 +28,16 @@ describe TextQuery do
     parse("text").eval("some textstring").should be_false
     parse("text").eval("string of texts stuff").should be_false
     parse("$^").eval("string of $^* stuff").should be_false
+    parse("NOTtext").eval("string of stuff").should be_false
+    parse("NOTtext").eval("string of NOTtext stuff with text").should be_true
   end
 
   it "should accept logical AND" do
     parse("a AND b").eval("c").should be_false
     parse("a AND b").eval("a").should be_false
     parse("a AND b").eval("b").should be_false
+    parse("a ANDb").eval("a b").should be_false
+    parse("a ANDb").eval("a ANDb").should be_true
 
     parse("a AND b").eval("a b").should be_true
     parse("a AND b").eval("a c b").should be_true
@@ -41,6 +45,7 @@ describe TextQuery do
 
   it "should accept logical OR" do
     parse("a OR b").eval("c").should be_false
+    parse("a ORb").eval("b").should be_false
     parse("a OR b").eval("a").should be_true
     parse("a OR b").eval("b").should be_true
 


### PR DESCRIPTION
Our branches have a number of common commits, but just these five changed files add attribute support.
I had to move the storage of the options hash onto the parser object (to make it accessible), but that doesn't otherwise affect the logic.
